### PR TITLE
Update Ubuntu iso

### DIFF
--- a/trusty.json
+++ b/trusty.json
@@ -2,8 +2,8 @@
   "variables": {
     "ssh_username": "vagrant",
     "ssh_password": "vagrant",
-    "iso_checksum": "401c5f6666fe2879ac3a9a3247b487723410cf88",
-    "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.1-server-amd64.iso"
+    "iso_checksum": "3bfa6eac84d527380d0cc52db9092cde127f161e",
+    "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso"
   },
   "builders": [
     {


### PR DESCRIPTION
Ubuntu iso link was throwing a 404, I've updated it to the latest version (14.04.1 -> 14.04.2) with correct checksum.
