### PR TITLE
Add default hostfile for ansible

### DIFF
--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -8,10 +8,17 @@ apt-get update
 # Upgrade all installed packages incl. kernel and kernel headers
 apt-get -y upgrade linux-server linux-headers-server
 
-# ensure the correct kernel headers are installed
+# Ensure the correct kernel headers are installed
 apt-get -y install linux-headers-$(uname -r)
 
+# Install ansible
 apt-get -y install ansible
+
+# Create a default hosts file for ansible
+cat <<EOF >/etc/ansible/hosts
+[local]
+localhost
+EOF
 
 apt-get -y install nfs-common portmap
 


### PR DESCRIPTION
This adds a default hosts file for Ansible, the standard Ansible hosts file is fill of test IP's and example domains and may cause issues in certain situations.

Tested and working. :+1: 
